### PR TITLE
fix!: rename screw_pitch to screw_lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ then calculates the amount you need to rotate one of the motor screws.
 If we have to rotate clockwise by 1 hour and 20 minutes,
 it means that we need to rotate the motor 1 full rotation for the hour,
 then another third of a rotation for the 20 minutes.
-Calculation is done using the pitch of your lead screw.
+Calculation is done using the lead of your lead screw.
 This is the only input you need to provide.
 
 As more people use this and contribute,
@@ -59,7 +59,7 @@ To ease installation, there is a script you can simply curl and execute.
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jomik/klipper-z-tramming/main/install.sh)"
 ```
 
-Then you only need to configure your lead screw pitch. See [How to configure it?](#how-to-configure-it).
+Then you only need to configure your lead screw lead. See [How to configure it?](#how-to-configure-it).
 
 ### Manual installation
 
@@ -106,8 +106,10 @@ EOF
 
 ## How to configure it?
 
-Open `z_tramming_settings.cfg` and uncomment the line with `variable_screw_pitch`,
-set the number to your pitch.
+Open `z_tramming_settings.cfg` and uncomment the line with `variable_screw_lead`,
+set the number to your lead. The lead is the distance the screw moves in one rotation.
+It is calculated by multiplying the pitch with the number of starts of the screw.
+So a 2mm pitch, 4 start screw has a lead of 8mm.
 You can look at the examples in the file for some known values.
 
 ## Alternatives

--- a/macros/z_tramming.cfg
+++ b/macros/z_tramming.cfg
@@ -13,8 +13,8 @@ gcode:
   {% if config is undefined %}
     {action_raise_error("Missing _Z_TRAMMING_SETTINGS macro")}
   {% endif %}
-  {% if config.screw_pitch is undefined %}
-    {action_raise_error("Missing screw_pitch in _Z_TRAMMING_SETTINGS macro")}
+  {% if config.screw_lead is undefined %}
+    {action_raise_error("Missing screw_lead in _Z_TRAMMING_SETTINGS macro")}
   {% endif %}
 
   {% set speed = config.speed | default(printer.configfile.settings.safe_z_home.speed) * 60 %}
@@ -61,7 +61,7 @@ gcode:
   {% set config = printer["gcode_macro _Z_TRAMMING_SETTINGS"] %}
   {% set probe = printer.configfile.settings.probe %}
   {% set tolerance = config.tolerance | default(probe.samples_tolerance * 2)%}
-  {% set screw_pitch = config.screw_pitch %}
+  {% set screw_lead = config.screw_lead %}
 
   {% set variance = (left - right) | abs %}
 
@@ -71,9 +71,9 @@ gcode:
     RESPOND TYPE=error MSG='{"Right is %0.3fmm %s" % (variance, right_is)}'
 
     {action_respond_info("01:20 means 1 full turn and 20 minutes, CW = clockwise, CCW = counter clockwise")}
-    # One full turn will move the Z axis by the screw pitch
-    {% set hours = (variance / screw_pitch) | int %}
-    {% set minutes = ((variance / screw_pitch * 60) % 60) | int %}
+    # One full turn will move the Z axis by the screw lead
+    {% set hours = (variance / screw_lead) | int %}
+    {% set minutes = ((variance / screw_lead * 60) % 60) | int %}
     {% set direction = "CCW" if left > right else "CW" %}
 
     RESPOND TYPE=command MSG="action:prompt_begin Z axis needs adjustment"
@@ -85,7 +85,7 @@ gcode:
       RESPOND TYPE=command MSG="action:prompt_text 01:20 means 1 full turn and 20 minutes, CW = clockwise, CCW = counter-clockwise"
     {% else %}
       # Display seconds because getting a rotation of 0 minutes is not helpful
-      {% set seconds = ((variance / screw_pitch * 60 * 60) % 60) | int %}
+      {% set seconds = ((variance / screw_lead * 60 * 60) % 60) | int %}
       RESPOND TYPE=error MSG='{"Turn the right lead screw %02d seconds %s" % (seconds, direction)}'
       RESPOND TYPE=command MSG='{"action:prompt_text Turn the right lead screw %02d seconds %s" % (seconds, direction)}'
     {% endif %}

--- a/macros/z_tramming_settings.cfg
+++ b/macros/z_tramming_settings.cfg
@@ -1,6 +1,6 @@
 # This macro contains the configuration variables for the Z Tramming macro
 [gcode_macro _Z_TRAMMING_SETTINGS]
-# variable_screw_pitch: 2 # Required! The pitch of Z lead screws in mm.
+# variable_screw_lead: 4 # Required! The lead of Z lead screws in mm. This is the distance the Z axis moves for one full rotation of the lead screw. It is calculated by measuring the pitch and counting the number of starts/threads.
 # variable_tolerance: 0.04 # Defaults to double the probe.samples_tolerance
 # variable_y_position: 51 # Defaults to probe at the center of bed
 # variable_left: 0 # Defaults to minmum position accounting for probe offset
@@ -10,10 +10,10 @@ gcode:
 
 # This is an example for a Sovol SV06
 # [gcode_macro _Z_TRAMMING_SETTINGS]
-# variable_screw_pitch: 2
+# variable_screw_lead: 4
 # gcode:
 
 # This is an example for a Sovol SV06 Plus
 # [gcode_macro _Z_TRAMMING_SETTINGS]
-# variable_screw_pitch: 4
+# variable_screw_lead: 4
 # gcode:


### PR DESCRIPTION
I have since learned that the movement caused by a full rotation of the lead screw is called the lead.
A 1 start 2mm pitch lead screw has a lead of 2mm.
But the SV06 has a 2mm pitch 2 start, with a lead of 4mm.

This caused wrong estimated turns with my example configuration.